### PR TITLE
reduce label and serach input to a single line

### DIFF
--- a/js/dataTables.semanticui.js
+++ b/js/dataTables.semanticui.js
@@ -66,7 +66,7 @@ $.extend( true, DataTable.defaults, {
 /* Default class modification */
 $.extend( DataTable.ext.classes, {
 	sWrapper:      "dataTables_wrapper dt-semanticUI",
-	sFilter:       "dataTables_filter ui form",
+	sFilter:       "dataTables_filter ui input",
 	sProcessing:   "dataTables_processing ui segment",
 	sPageButton:   "paginate_button item"
 } );
@@ -203,6 +203,7 @@ $(document).on( 'init.dt', function (e, ctx) {
 	}
 
 	// Filtering input
+	$( 'div.dataTables_filter.ui.input', api.table().container() ).removeClass('input').addClass('form');
 	$( 'div.dataTables_filter input', api.table().container() ).wrap( '<span class="ui input" />' );
 } );
 


### PR DESCRIPTION
With the ui form wrapper the label and input requiere two lines. After the initialization is finished, the view changes to one line. This repositions the table and bounces the page.